### PR TITLE
docs: Replace simplistic with simple to get the intended connotation

### DIFF
--- a/en/aws/index.md
+++ b/en/aws/index.md
@@ -1,7 +1,7 @@
 # &#x1f329; architect
 ## Provision and deploy cloud architecture as text
 
-Event driven programming with cloud functions is tricky to setup and maintain. `architect` offers a simplistic plaintext manifest and `npm` script based workflows for creating, deploying, working offline and more.
+Event driven programming with cloud functions is tricky to setup and maintain. `architect` offers a simple plaintext manifest and `npm` script based workflows for creating, deploying, working offline and more.
 
 Currently, architect` supports the following Amazon Web Services:
 

--- a/en/aws/intro-concepts.md
+++ b/en/aws/intro-concepts.md
@@ -17,7 +17,7 @@ The tradeoff is you are committing AWS configuration knowledge into your revisio
 
 ## The .arc file
 
-`architect` defines a simplistic plaintext format, `.arc`, as a manfiest file to solve the specific problems laid out above.
+`architect` defines a simple plaintext format, `.arc`, as a manfiest file to solve the specific problems laid out above.
 
 With `architect`, you can:
 


### PR DESCRIPTION
See the [confusables note](http://www.dictionary.com/browse/simplistic) for simplistic - it isn't a
'relating-to' form like minimalistic or probabalistic. Instead, simplistic means over-simplified,
and comes with a distinctly negative connotation. Simple, on the other hand, means simple.